### PR TITLE
Fix Flaky Test

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -507,8 +507,8 @@ def tests_patch_get_outputs():
 
 
 def tests_patch___new__():
-    from compilertools.build import get_build_compile_args
     """Test _patch___new__"""
+    from compilertools.build import get_build_compile_args
     # Check if patched
     assert BUILD_EXT_NEW is not build_ext.__new__
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -507,6 +507,7 @@ def tests_patch_get_outputs():
 
 
 def tests_patch___new__():
+    from compilertools.build import get_build_compile_args
     """Test _patch___new__"""
     # Check if patched
     assert BUILD_EXT_NEW is not build_ext.__new__


### PR DESCRIPTION
<h2>What is the purpose of this PR</h2>

- This PR patches `tests/test_build.py::tests_patch___new__` and prevents it from failing when it is run by itself
- Test is flaky (non-deterministic) and depends on `tests/test_build.py::tests_get_build_compile_args` to set up a state to pass, but the test fails when it is run by itself otherwise

---

<h2>Expected Result</h2> 

- Test `tests/test_build.py::tests_patch___new__` should pass when run both by itself and after `tests/test_build.py::tests_get_build_compile_args`

---
<h2>Actual Result</h2> 

- Test `tests/test_build.py::tests_patch___new__`  fails when it is run by itself
- Specifically, we get the following
```
_______________________________________________________________________________________________ tests_patch___new__ _______________________________________________________________________________________________

    def tests_patch___new__():
        """Test _patch___new__"""
        # Check if patched
>       assert BUILD_EXT_NEW is not build_ext.__new__
E       assert BUILD_EXT_NEW is not <built-in method __new__ of type object at 0x9075a0>
E        +  where <built-in method __new__ of type object at 0x9075a0> = build_ext.__new__

tests/test_build.py:512: AssertionError
```

---

<h2>Reproduce the test failure</h2>

- Run `python3 -m pytest tests/test_build.py::tests_patch___new__` 

---
<h2>Why the Test Fails</h2> 

- The test fails because the test is dependent on some state that is not set when it is run by itself. 

---
<h2>Fix</h2>

- The changes in this pull request sets the state and makes the test pass when it is run by itself. 

---
